### PR TITLE
WebdavUtils - Don't statically allocate the SimpleDateObject (rebased)

### DIFF
--- a/src/com/owncloud/android/lib/common/network/WebdavUtils.java
+++ b/src/com/owncloud/android/lib/common/network/WebdavUtils.java
@@ -35,15 +35,15 @@ import android.net.Uri;
 public class WebdavUtils {
     public static final SimpleDateFormat DISPLAY_DATE_FORMAT = new SimpleDateFormat(
             "dd.MM.yyyy hh:mm");
-    private static final SimpleDateFormat DATETIME_FORMATS[] = {
-            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'", Locale.US),
-            new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US),
-            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.sss'Z'", Locale.US),
-            new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US),
-            new SimpleDateFormat("EEE MMM dd HH:mm:ss zzz yyyy", Locale.US),
-            new SimpleDateFormat("EEEEEE, dd-MMM-yy HH:mm:ss zzz", Locale.US),
-            new SimpleDateFormat("EEE MMMM d HH:mm:ss yyyy", Locale.US) ,
-    		new SimpleDateFormat("yyyy-MM-dd hh:mm:ss") };
+    private static final String DATETIME_FORMATS[] = {
+            "yyyy-MM-dd'T'HH:mm:ss'Z'",
+            "EEE, dd MMM yyyy HH:mm:ss zzz",
+            "yyyy-MM-dd'T'HH:mm:ss.sss'Z'",
+            "yyyy-MM-dd'T'HH:mm:ssZ",
+            "EEE MMM dd HH:mm:ss zzz yyyy",
+            "EEEEEE, dd-MMM-yy HH:mm:ss zzz",
+            "EEE MMMM d HH:mm:ss yyyy",
+            "yyyy-MM-dd hh:mm:ss" };
 
     public static String prepareXmlForPropFind() {
         String ret = "<?xml version=\"1.0\" ?><D:propfind xmlns:D=\"DAV:\"><D:allprop/></D:propfind>";
@@ -58,7 +58,7 @@ public class WebdavUtils {
         Date returnDate = null;
         for (int i = 0; i < DATETIME_FORMATS.length; ++i) {
             try {
-                returnDate = DATETIME_FORMATS[i].parse(date);
+                returnDate = new SimpleDateFormat (DATETIME_FORMATS[i]).parse(date);
                 return returnDate;
             } catch (ParseException e) {
             }


### PR DESCRIPTION
When accessing this from multiple threads we get inconsistent states of
parsed value leading to the wrong date being returned.
