### PR TITLE
Fix encoding

### DIFF
--- a/src/com/owncloud/android/lib/resources/shares/CreateRemoteShareOperation.java
+++ b/src/com/owncloud/android/lib/resources/shares/CreateRemoteShareOperation.java
@@ -66,20 +66,20 @@ public class CreateRemoteShareOperation extends RemoteOperation {
 	/**
 	 * Constructor
 	 * @param remoteFilePath	Full path of the file/folder being shared. Mandatory argument
-	 * @param shareType			‘0’ = user, ‘1’ = group, ‘3’ = Public link. Mandatory argument
+	 * @param shareType			'0' = user, '1' = group, '3' = Public link. Mandatory argument
 	 * @param shareWith			User/group ID with who the file should be shared.  This is mandatory for shareType of 0 or 1
-	 * @param publicUpload		If ‘false’ (default) public cannot upload to a public shared folder. 
-	 * 							If ‘true’ public can upload to a shared folder. Only available for public link shares
+	 * @param publicUpload		If 'false' (default) public cannot upload to a public shared folder. 
+	 * 							If 'true' public can upload to a shared folder. Only available for public link shares
 	 * @param password			Password to protect a public link share. Only available for public link shares
-	 * @param permissions		1 - Read only – Default for “public” shares
+	 * @param permissions		1 - Read only â€“ Default for "public" shares
 	 * 							2 - Update
 	 * 							4 - Create
 	 * 							8 - Delete
 	 * 							16- Re-share
-	 * 							31- All above – Default for “private” shares
+	 * 							31- All above â€“ Default for "private" shares
 	 * 							For user or group shares.
 	 * 							To obtain combinations, add the desired values together.  
-	 * 							For instance, for “Re-Share”, “delete”, “read”, “update”, add 16+8+2+1 = 27.
+	 * 							For instance, for "Re-Share", "delete", "read", "update", add 16+8+2+1 = 27.
 	 */
 	public CreateRemoteShareOperation(String remoteFilePath, ShareType shareType, String shareWith, boolean publicUpload, 
 			String password, int permissions) {

--- a/src/com/owncloud/android/lib/resources/shares/CreateRemoteShareOperation.java
+++ b/src/com/owncloud/android/lib/resources/shares/CreateRemoteShareOperation.java
@@ -71,12 +71,12 @@ public class CreateRemoteShareOperation extends RemoteOperation {
 	 * @param publicUpload		If 'false' (default) public cannot upload to a public shared folder. 
 	 * 							If 'true' public can upload to a shared folder. Only available for public link shares
 	 * @param password			Password to protect a public link share. Only available for public link shares
-	 * @param permissions		1 - Read only – Default for "public" shares
+	 * @param permissions		1 - Read only - Default for "public" shares
 	 * 							2 - Update
 	 * 							4 - Create
 	 * 							8 - Delete
 	 * 							16- Re-share
-	 * 							31- All above – Default for "private" shares
+	 * 							31- All above - Default for "private" shares
 	 * 							For user or group shares.
 	 * 							To obtain combinations, add the desired values together.  
 	 * 							For instance, for "Re-Share", "delete", "read", "update", add 16+8+2+1 = 27.

--- a/src/com/owncloud/android/lib/resources/shares/GetRemoteSharesForFileOperation.java
+++ b/src/com/owncloud/android/lib/resources/shares/GetRemoteSharesForFileOperation.java
@@ -65,10 +65,10 @@ public class GetRemoteSharesForFileOperation extends RemoteOperation {
 	 * Constructor
 	 * 
 	 * @param remoteFilePath	Path to file or folder
-	 * @param reshares			If set to ‘false’ (default), only shares from the current user are returned
-	 * 							If set to ‘true’, all shares from the given file are returned
-	 * @param subfiles			If set to ‘false’ (default), lists only the folder being shared
-	 * 							If set to ‘true’, all shared files within the folder are returned.
+	 * @param reshares			If set to 'false' (default), only shares from the current user are returned
+	 * 							If set to 'true', all shares from the given file are returned
+	 * @param subfiles			If set to 'false' (default), lists only the folder being shared
+	 * 							If set to 'true', all shared files within the folder are returned.
 	 */
 	public GetRemoteSharesForFileOperation(String remoteFilePath, boolean reshares, boolean subfiles) {
 		mRemoteFilePath = remoteFilePath;


### PR DESCRIPTION
This fixes problems when building the lib from source like:

```
    [javac] /usr/src/oc-android-library/src/com/owncloud/android/lib/resources/shares/CreateRemoteShareOperation.java:69: warning: unmappable character for encoding UTF-8
    [javac] 	 * @param shareType			�0� = user, �1� = group, �3� = Public link. Mandatory argument
```