### PR TITLE
Close resource in finally block

### DIFF
--- a/src/com/owncloud/android/lib/common/utils/Log_OC.java
+++ b/src/com/owncloud/android/lib/common/utils/Log_OC.java
@@ -167,10 +167,15 @@ public class Log_OC {
 	            mBuf.newLine();
 	            mBuf.write(text);
 	            mBuf.newLine();
-	            mBuf.close();
 	        } catch (IOException e) {
 	            e.printStackTrace();
-	        }
+	        } finally {
+                try {
+                    mBuf.close();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
 
             // Check if current log file size is bigger than the max file size defined
             if (mLogFile.length() > MAX_FILE_SIZE) {

--- a/src/com/owncloud/android/lib/common/utils/Log_OC.java
+++ b/src/com/owncloud/android/lib/common/utils/Log_OC.java
@@ -60,7 +60,7 @@ public class Log_OC {
     }
     
     public static void w(String TAG, String message) {
-        Log.w(TAG,message);
+        Log.w(TAG, message);
         appendLog(TAG+" : "+ message);
     }
     
@@ -99,8 +99,16 @@ public class Log_OC {
             }
 
         } catch (IOException e) {
-            e.printStackTrace(); 
-        } 
+            e.printStackTrace();
+        } finally {
+            if(mBuf != null) {
+                try {
+                    mBuf.close();
+                } catch(IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
I don't quite get the reason for `mBuf` here as in `com.owncloud.android.lib.common.utils.Log_OC#appendLog` anyways a new `BufferedWriter` is started but it might make sense to close this here as this will otherwise cause warnings in static code scanners.

Didn't test this as I don't have a Android device and so it requires extensive testing.

<!---
@huboard:{"order":35.75,"milestone_order":68}
-->
