### PR TITLE
If server URL contains credentials, use them in the status check

### DIFF
--- a/src/com/owncloud/android/lib/resources/status/GetRemoteStatusOperation.java
+++ b/src/com/owncloud/android/lib/resources/status/GetRemoteStatusOperation.java
@@ -89,8 +89,11 @@ public class GetRemoteStatusOperation extends RemoteOperation {
             Uri uri = Uri.parse(baseUrlSt);
             String userInfo = uri.getUserInfo();
             if(userInfo != null) {
-                OwnCloudCredentials creds = OwnCloudCredentialsFactory.newBasicCredentials(userInfo.split(":", 2)[0], userInfo.split(":", 2)[1]);
-                client.setCredentials(creds);
+                String[] userInfoParts = userInfo.split(":", 2);
+                if(userInfoParts.length == 2) {
+                    OwnCloudCredentials creds = OwnCloudCredentialsFactory.newBasicCredentials(userInfoParts[0], userInfoParts[1]);
+                    client.setCredentials(creds);
+                }
             }
 
             client.setFollowRedirects(false);

--- a/src/com/owncloud/android/lib/resources/status/GetRemoteStatusOperation.java
+++ b/src/com/owncloud/android/lib/resources/status/GetRemoteStatusOperation.java
@@ -39,6 +39,8 @@ import android.net.Uri;
 
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.OwnCloudClientManagerFactory;
+import com.owncloud.android.lib.common.OwnCloudCredentials;
+import com.owncloud.android.lib.common.OwnCloudCredentialsFactory;
 import com.owncloud.android.lib.common.accounts.AccountUtils;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
@@ -83,6 +85,13 @@ public class GetRemoteStatusOperation extends RemoteOperation {
             params.setParameter(HttpMethodParams.USER_AGENT,
                     OwnCloudClientManagerFactory.getUserAgent());
             get.getParams().setDefaults(params);
+
+            Uri uri = Uri.parse(baseUrlSt);
+            String userInfo = uri.getUserInfo();
+            if(userInfo != null) {
+                OwnCloudCredentials creds = OwnCloudCredentialsFactory.newBasicCredentials(userInfo.split(":", 2)[0], userInfo.split(":", 2)[1]);
+                client.setCredentials(creds);
+            }
 
             client.setFollowRedirects(false);
             boolean isRedirectToNonSecureConnection = false;


### PR DESCRIPTION
The http client by default ignores http basic auth credentials in the server URL when doing the status check. Goes with https://github.com/owncloud/android/pull/1438.