### PR TITLE
Update gradle android plugin to 2.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.0'
     }
 }
 


### PR DESCRIPTION
With the new Android Studio 2.1 an new version of the android gradle plugin was made available v2.1.0