### PR TITLE
Update entry point to get user info

### DIFF
--- a/src/com/owncloud/android/lib/resources/users/GetRemoteUserInfoOperation.java
+++ b/src/com/owncloud/android/lib/resources/users/GetRemoteUserInfoOperation.java
@@ -48,7 +48,7 @@ public class GetRemoteUserInfoOperation extends RemoteOperation {
     private static final String TAG = GetRemoteUserInfoOperation.class.getSimpleName();
 
     // OCS Route
-    private static final String OCS_ROUTE = "/index.php/ocs/cloud/user?format=json";
+    private static final String OCS_ROUTE = "/ocs/v1.php/cloud/user?format=json";
 
     // JSON Node names
     private static final String NODE_OCS = "ocs";


### PR DESCRIPTION
Fixes wrong path to UserInfo resource that was taking advantage of extra "intelligence" in server version to redirect paths, dropped with OC server 10.