### PR TITLE
[WIP] Update Android tools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ android:
 # second 'tools' updates SDK tools 'til last version ** in remote repository number 11 ** (current last one)
   - tools
   - platform-tools
-  - build-tools-25.0.2
+  - build-tools-26.0.0
   - android-24
   - sys-img-armeabi-v7a-android-24
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ android:
   components:
   - tools
   - platform-tools
-  - build-tools-26.0.0
+  - build-tools-26.0.2
   - android-24
   - sys-img-armeabi-v7a-android-24
 branches:
@@ -16,13 +16,17 @@ before_install:
 # After Travis updated image with Android base environment, building via ant is not possible anymore.
 # Library tests are old-style tests, and trust on legacy Android ant environment.
 # Need to disable tests until they are ported to JUnit 4 and gradle build.
-#- echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI
-  -c 20M
+#- echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI -c 20M
 #- emulator -avd test -no-window &
 - rm pom.xml
 #- android update project -p .
 #- chmod +x ./wait_for_emulator.sh
 #- ./wait_for_emulator.sh
+# 
+# On the other hand, Travis still uses 'android' command behind the 'components' section update. 
+# That command is obsolete and cannot update Android SDK Tools after 25.2.5.
+# Let's solve it here with the new command 'sdkmanager'
+- yes | sdkmanager --verbose tools
 script:
 #- ant clean
 #- ant debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ install:
 - yes | sdkmanager --verbose "tools"
 - yes | sdkmanager --verbose "platforms;android-24"
 - yes | sdkmanager --verbose "system-images;android-24;default;armeabi-v7a"
+
+# Check tools and dependencies installed
+- yes | sdkmanager --list
+
 # After Travis updated image with Android base environment, building via ant is not possible anymore.
 # Library tests are old-style tests, and trust on legacy Android ant environment.
 # Need to disable tests until they are ported to JUnit 4 and gradle build.

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,19 +13,22 @@ branches:
   only:
   - master
 before_install:
-- echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI
+# After Travis updated image with Android base environment, building via ant is not possible anymore.
+# Library tests are old-style tests, and trust on legacy Android ant environment.
+# Need to disable tests until they are ported to JUnit 4 and gradle build.
+#- echo no | android create avd --force -n test -t $ANDROID_TARGET --abi $ANDROID_ABI
   -c 20M
-- emulator -avd test -no-window &
+#- emulator -avd test -no-window &
 - rm pom.xml
-- android update project -p .
-- chmod +x ./wait_for_emulator.sh
-- ./wait_for_emulator.sh
+#- android update project -p .
+#- chmod +x ./wait_for_emulator.sh
+#- ./wait_for_emulator.sh
 script:
-- ant clean
-- ant debug
-- cd test_client/tests
-- ant acceptance-test
-- cd ../..
+#- ant clean
+#- ant debug
+#- cd test_client/tests
+#- ant acceptance-test
+#- cd ../..
 - ./gradlew clean build
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ jdk:
   - oraclejdk8
 android:
   components:
-# first 'tools' updates SDK tools 'til last version ** in remote repository number 10 **
-  - tools
-# second 'tools' updates SDK tools 'til last version ** in remote repository number 11 ** (current last one)
   - tools
   - platform-tools
   - build-tools-26.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,16 @@ sudo: false
 language: android
 jdk:
   - oraclejdk8
-android:
-  components:
-  - tools
-  - platform-tools
-  - build-tools-26.0.2
-  - android-24
-  - sys-img-armeabi-v7a-android-24
 branches:
   only:
   - master
-before_install:
+install:
+# Let's use the new command 'sdkmanager' to install Android SDK components
+- yes | sdkmanager --verbose "build-tools;26.0.2"
+- yes | sdkmanager --verbose "platform-tools"
+- yes | sdkmanager --verbose "tools"
+- yes | sdkmanager --verbose "platforms;android-24"
+- yes | sdkmanager --verbose "system-images;android-24;default;armeabi-v7a"
 # After Travis updated image with Android base environment, building via ant is not possible anymore.
 # Library tests are old-style tests, and trust on legacy Android ant environment.
 # Need to disable tests until they are ported to JUnit 4 and gradle build.

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 
 android {
     compileSdkVersion 24
-    buildToolsVersion '26.0.0'
+    buildToolsVersion '26.0.2'
 
     sourceSets {
         main {

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 
 android {
     compileSdkVersion 24
-    buildToolsVersion '25.0.2'
+    buildToolsVersion '26.0.0'
 
     sourceSets {
         main {

--- a/sample_client/build.gradle
+++ b/sample_client/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "25.0.2"
+    buildToolsVersion "26.0.0"
 
     sourceSets {
         main {

--- a/sample_client/build.gradle
+++ b/sample_client/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "26.0.0"
+    buildToolsVersion "26.0.2"
 
     sourceSets {
         main {

--- a/test_client/build.gradle
+++ b/test_client/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "25.0.2"
+    buildToolsVersion "26.0.0"
 
     sourceSets {
         main {

--- a/test_client/build.gradle
+++ b/test_client/build.gradle
@@ -12,7 +12,7 @@ dependencies {
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "26.0.0"
+    buildToolsVersion "26.0.2"
 
     sourceSets {
         main {

--- a/test_client/tests/build.gradle
+++ b/test_client/tests/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    buildToolsVersion "26.0.0"
 
     sourceSets {
         main {

--- a/test_client/tests/build.gradle
+++ b/test_client/tests/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "26.0.0"
+    buildToolsVersion "26.0.2"
 
     sourceSets {
         main {


### PR DESCRIPTION
Dependencies to update:

- [x] **buildTools**: 
  - Update locally via SDK Manager and select version to use in build.gradle: `buildToolsVersion '26.0.2'`
  - .travis.yml: `- build-tools-26.0.2`
- [x] **platformTools**: 
  - Update locally via SDK Manager to 26.0.1
  - .travis.yml: `- platform-tools`
- [x] **tools**: 
  - Update locally via SDK Manager to 26.1.1
  - .travis.yml: ~~`- tools` and `yes | - sdkmanager --verbose tools` (not updating properly, travis first install tools 25.2.5 and replace it with 25.2.3 version)~~ Fixed by using the new sdkmanager to install all the Android SDK dependencies and deleting the android components section.