### PR TITLE
check for PROPERTY_VERSIONING is exist when learning capabilities

### DIFF
--- a/src/com/owncloud/android/lib/resources/status/GetRemoteCapabilitiesOperation.java
+++ b/src/com/owncloud/android/lib/resources/status/GetRemoteCapabilitiesOperation.java
@@ -1,6 +1,7 @@
 /* ownCloud Android Library is available under MIT license
  *   @author masensio
- *   Copyright (C) 2016 ownCloud GmbH.
+ *   @author Semih Serhat Karakaya <karakayasemi@itu.edu.tr>
+ *   Copyright (C) 2018 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal
@@ -245,8 +246,10 @@ public class GetRemoteCapabilitiesOperation extends RemoteOperation {
                                 capability.setFilesUndelete(CapabilityBooleanType.fromBooleanValue(
                                         respFiles.getBoolean(PROPERTY_UNDELETE)));
                             }
-                            capability.setFilesVersioning(CapabilityBooleanType.fromBooleanValue(
-                                    respFiles.getBoolean(PROPERTY_VERSIONING)));
+                            if (respFiles.has(PROPERTY_VERSIONING)) {
+                                capability.setFilesVersioning(CapabilityBooleanType.fromBooleanValue(
+                                        respFiles.getBoolean(PROPERTY_VERSIONING)));
+                            }
                             Log_OC.d(TAG, "*** Added " + NODE_FILES);
                         }
                     }


### PR DESCRIPTION
Fix for https://github.com/owncloud/android/issues/2078 . 

Summary: If files_versioning app is disabled, server capabilities response does not include any information about versioning. Trying to access undefined index is leading to an error in "GetRemoteCapabilitiesOperation" and client cannot determine server version. To fix the problem, I added "has" check for "PROPERTY_VERSIONING".