### PR TITLE
fix a bug with wrong used OC_X_REQUEST_ID

### DIFF
--- a/src/com/owncloud/android/lib/common/OwnCloudClient.java
+++ b/src/com/owncloud/android/lib/common/OwnCloudClient.java
@@ -172,7 +172,7 @@ public class OwnCloudClient extends HttpClient {
         String requestId = RandomUtils.generateRandomUUID();
 
         // Header to allow tracing requests in apache and ownCloud logs
-        addHeaderForAllRequests(OC_X_REQUEST_ID, RandomUtils.generateRandomUUID());
+        addHeaderForAllRequests(OC_X_REQUEST_ID, requestId);
 
         Log_OC.d(TAG, "Executing " + method.getClass().getSimpleName() + " in request with id " + requestId);
     }


### PR DESCRIPTION
For logging it was used a separate OC_X_REQUEST_ID and makes the logging complete wrong

Btw , currently I see no sense to set this OC_X_REQUEST_ID at all