### PR TITLE
compact logfile

### DIFF
--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/utils/Log_OC.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/utils/Log_OC.java
@@ -8,6 +8,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
+import java.util.Locale;
 
 public class Log_OC {
     private static final String SIMPLE_DATE_FORMAT = "yyyy/MM/dd HH:mm:ss";
@@ -114,7 +115,6 @@ public class Log_OC {
             mFolder = null;
             mBuf = null;
             isMaxFileSizeReached = false;
-            isEnabled = false;
 
         } catch (IOException e) {
             // Because we are stopping logging, we only log to Android console.
@@ -134,8 +134,8 @@ public class Log_OC {
         File folderLogs = new File(mFolder + File.separator);
         if(folderLogs.isDirectory()){
             String[] myFiles = folderLogs.list();
-            for (int i=0; i<myFiles.length; i++) {
-                File myFile = new File(folderLogs, myFiles[i]);
+            for (String myFile1 : myFiles) {
+                File myFile = new File(folderLogs, myFile1);
                 myFile.delete();
             }
         }
@@ -174,15 +174,12 @@ public class Log_OC {
                 isMaxFileSizeReached = false;
             }
 
-	        String timeStamp = new SimpleDateFormat(SIMPLE_DATE_FORMAT).format(Calendar.getInstance().getTime());
+	        String timeStamp = new SimpleDateFormat(SIMPLE_DATE_FORMAT, Locale.ENGLISH).format(Calendar.getInstance().getTime());
 
 	        try {
 	            mBuf = new BufferedWriter(new FileWriter(mLogFile, true));
 	            mBuf.newLine();
-	            mBuf.write(timeStamp);
-	            mBuf.newLine();
-	            mBuf.write(text);
-	            mBuf.newLine();
+	            mBuf.write(timeStamp+" "+text);
 	        } catch (IOException e) {
 	            e.printStackTrace();
 	        } finally {

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/utils/Log_OC.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/utils/Log_OC.java
@@ -26,50 +26,53 @@ public class Log_OC {
     private static boolean isMaxFileSizeReached = false;
     private static boolean isEnabled = false;
 
-    public static void setLogDataFolder(String logFolder){
-    	mOwncloudDataFolderLog = logFolder;
+    public static void setLogDataFolder(String logFolder) {
+        mOwncloudDataFolderLog = logFolder;
     }
 
-    public static void i(String TAG, String message){
+    public static void i(String TAG, String message) {
         Log.i(TAG, message);
-        appendLog(TAG+" : "+ message);
+        appendLog(TAG + " : " + message);
     }
 
-    public static void d(String TAG, String message){
+    public static void d(String TAG, String message) {
         Log.d(TAG, message);
         appendLog(TAG + " : " + message);
     }
+
     public static void d(String TAG, String message, Exception e) {
         Log.d(TAG, message, e);
-        appendLog(TAG + " : " + message + " Exception : "+ e.getStackTrace());
+        appendLog(TAG + " : " + message + " Exception : " + e.getStackTrace());
     }
-    public static void e(String TAG, String message){
+
+    public static void e(String TAG, String message) {
         Log.e(TAG, message);
         appendLog(TAG + " : " + message);
     }
-    
+
     public static void e(String TAG, String message, Throwable e) {
         Log.e(TAG, message, e);
-        appendLog(TAG+" : " + message +" Exception : " + e.getStackTrace());
+        appendLog(TAG + " : " + message + " Exception : " + e.getStackTrace());
     }
-    
-    public static void v(String TAG, String message){
+
+    public static void v(String TAG, String message) {
         Log.v(TAG, message);
-        appendLog(TAG+" : "+ message);
+        appendLog(TAG + " : " + message);
     }
-    
+
     public static void w(String TAG, String message) {
         Log.w(TAG, message);
-        appendLog(TAG+" : "+ message);
+        appendLog(TAG + " : " + message);
     }
 
     /**
      * Start doing logging
+     *
      * @param storagePath : directory for keeping logs
      */
     synchronized public static void startLogging(String storagePath) {
-		String logPath = storagePath + File.separator +
-			mOwncloudDataFolderLog + File.separator + LOG_FOLDER_NAME;
+        String logPath = storagePath + File.separator +
+                mOwncloudDataFolderLog + File.separator + LOG_FOLDER_NAME;
         mFolder = new File(logPath);
         mLogFile = new File(mFolder + File.separator + mLogFileNames[0]);
 
@@ -81,7 +84,7 @@ public class Log_OC {
             Log.d("LOG_OC", "Log file created");
         }
 
-        try { 
+        try {
 
             // Create the current log file if does not exist
             mLogFile.createNewFile();
@@ -95,10 +98,10 @@ public class Log_OC {
         } catch (IOException e) {
             e.printStackTrace();
         } finally {
-            if(mBuf != null) {
+            if (mBuf != null) {
                 try {
                     mBuf.close();
-                } catch(IOException e) {
+                } catch (IOException e) {
                     e.printStackTrace();
                 }
             }
@@ -107,8 +110,9 @@ public class Log_OC {
 
     synchronized public static void stopLogging() {
         try {
-			if (mBuf != null)
+            if (mBuf != null) {
                 mBuf.close();
+            }
             isEnabled = false;
 
             mLogFile = null;
@@ -132,7 +136,7 @@ public class Log_OC {
      */
     public static void deleteHistoryLogging() {
         File folderLogs = new File(mFolder + File.separator);
-        if(folderLogs.isDirectory()){
+        if (folderLogs.isDirectory()) {
             String[] myFiles = folderLogs.list();
             for (String myFile1 : myFiles) {
                 File myFile = new File(folderLogs, myFile1);
@@ -140,7 +144,7 @@ public class Log_OC {
             }
         }
     }
-    
+
     /**
      * Append the info of the device
      */
@@ -152,9 +156,10 @@ public class Log_OC {
         appendLog("Version-Codename : " + android.os.Build.VERSION.CODENAME);
         appendLog("Version-Release : " + android.os.Build.VERSION.RELEASE);
     }
-    
+
     /**
      * Append to the log file the info passed
+     *
      * @param text : text for adding to the log file
      */
     synchronized private static void appendLog(String text) {
@@ -174,15 +179,15 @@ public class Log_OC {
                 isMaxFileSizeReached = false;
             }
 
-	        String timeStamp = new SimpleDateFormat(SIMPLE_DATE_FORMAT, Locale.ENGLISH).format(Calendar.getInstance().getTime());
+            String timeStamp = new SimpleDateFormat(SIMPLE_DATE_FORMAT, Locale.ENGLISH).format(Calendar.getInstance().getTime());
 
-	        try {
-	            mBuf = new BufferedWriter(new FileWriter(mLogFile, true));
-	            mBuf.newLine();
-	            mBuf.write(timeStamp+" "+text);
-	        } catch (IOException e) {
-	            e.printStackTrace();
-	        } finally {
+            try {
+                mBuf = new BufferedWriter(new FileWriter(mLogFile, true));
+                mBuf.newLine();
+                mBuf.write(timeStamp + " " + text);
+            } catch (IOException e) {
+                e.printStackTrace();
+            } finally {
                 try {
                     mBuf.close();
                 } catch (IOException e) {

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/utils/Log_OC.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/utils/Log_OC.java
@@ -138,9 +138,9 @@ public class Log_OC {
         File folderLogs = new File(mFolder + File.separator);
         if (folderLogs.isDirectory()) {
             String[] myFiles = folderLogs.list();
-            for (String myFile1 : myFiles) {
-                File myFile = new File(folderLogs, myFile1);
-                Log_OC.d("delete file", myFile.getAbsoluteFile() + " " + myFile.delete());
+            for (String fileName : myFiles) {
+                File fileInFolder = new File(folderLogs, fileName);
+                Log_OC.d("delete file", fileInFolder.getAbsoluteFile() + " " + fileInFolder.delete());
             }
         }
     }

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/utils/Log_OC.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/utils/Log_OC.java
@@ -136,7 +136,7 @@ public class Log_OC {
             String[] myFiles = folderLogs.list();
             for (String myFile1 : myFiles) {
                 File myFile = new File(folderLogs, myFile1);
-                myFile.delete();
+                Log_OC.d("delete file", myFile.getAbsoluteFile() + " " + myFile.delete());
             }
         }
     }


### PR DESCRIPTION
It needs https://github.com/owncloud/android/pull/2415

time and text in same line, no empty lines

### previous
```
2018/12/19 08:06:49
GetRemoteSharesForFileOperation : Got 1 shares

2018/12/19 08:06:49
FileDataStorageManager : Sending 16 operations to FileContentProvider

2018/12/19 08:06:49
FileContentProvider : applying batch in provider com.owncloud.android.providers.FileContentProvider@4402c7c (temporary: false)

2018/12/19 08:06:49
FileContentProvider : applied batch in provider com.owncloud.android.providers.FileContentProvider@4402c7c

2018/12/19 08:06:49
RefreshFolderOperation : Send broadcast com.owncloud.android.operations.RefreshFolderOperation.EVENT_SINGLE_FOLDER_SHARES_SYNCED
```
### It looks like this now

```
2018/12/19 08:46:38 FileDisplayActivity : onResume() starting
2018/12/19 08:46:38 OCFileListFragment : onAttach
2018/12/19 08:46:38 OCFileListFragment : onCreateView() start
2018/12/19 08:46:38 ExtendedListFragment : onCreateView
2018/12/19 08:46:39 OCFileListFragment : onCreateView() end
2018/12/19 08:46:39 OCFileListFragment : onActivityCreated() start
2018/12/19 08:46:39 FileDisplayActivity : onResume() end
2018/12/19 08:46:39 OperationsService : Creating service
2018/12/19 08:46:39 FileDownloader : Creating service
2018/12/19 08:46:39 FileUploader : Creating service
2018/12/19 08:46:39 UploadsStorageManager : Updating state of any killed upload
2018/12/19 08:46:39 UploadsStorageManager : No upload was killed
2018/12/19 08:46:39 cache_test_DISK_ : image read from disk -592799545
2018/12/19 08:46:40 cache_test_DISK_ : image read from disk -592799545
2018/12/19 08:46:40 FileActivity : Operations service connected
2018/12/19 08:46:40 FileDisplayActivity : Download service connected
```

now you can do `cat currentLog.txt | grep something` and see immediate findings and when it appears