### PR TITLE
Revert compileSdkVersion to 28

### DIFF
--- a/owncloudComLibrary/build.gradle
+++ b/owncloudComLibrary/build.gradle
@@ -16,7 +16,7 @@ allOpen {
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 19


### PR DESCRIPTION
`compileSdkVersion` was upgraded to 29 via https://github.com/owncloud/android-library/pull/266 but this is something we usually do through specific issues like https://github.com/owncloud/android/issues/2576 , so let's rever this scenario and delay the upgrade for later