### PR TITLE
Better logging

### DIFF
--- a/owncloudComLibrary/build.gradle
+++ b/owncloudComLibrary/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     api 'com.squareup.okhttp3:okhttp:3.12.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion"
     api 'com.gitlab.ownclouders:dav4android:oc_support_1.0.1'
+    api 'com.github.hannesa2:Logcat:1.5'
 }
 
 allOpen {

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/utils/Log_OC.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/utils/Log_OC.java
@@ -1,212 +1,52 @@
 package com.owncloud.android.lib.common.utils;
 
-import android.util.Log;
+import timber.log.Timber;
 
-import com.owncloud.android.lib.BuildConfig;
-
-import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Locale;
 
 public class Log_OC {
-    private static final String SIMPLE_DATE_FORMAT = "yyyy/MM/dd HH:mm:ss";
-    private static final String LOG_FOLDER_NAME = "log";
-    private static final long MAX_FILE_SIZE = 2000000; // 2MB
 
-    private static String mOwncloudDataFolderLog = "owncloud_log";
-
-    private static File mLogFile;
-    private static File mFolder;
-    private static BufferedWriter mBuf;
-
-    private static String[] mLogFileNames = {
-            "currentLog" + BuildConfig.BUILD_TYPE + ".txt",
-            "olderLog" + BuildConfig.BUILD_TYPE + ".txt"
-    };
-
-    private static boolean isMaxFileSizeReached = false;
-    private static boolean isEnabled = false;
+    private static String mOwncloudDataFolderLog;
 
     public static void setLogDataFolder(String logFolder) {
         mOwncloudDataFolderLog = logFolder;
     }
 
-    public static void i(String TAG, String message) {
-        Log.i(TAG, message);
-        appendLog("I: " + TAG + " : " + message);
+    public static void i(String tag, String message) {
+        Timber.i(message);
     }
 
     public static void d(String TAG, String message) {
-        Log.d(TAG, message);
-        appendLog("D: " + TAG + " : " + message);
+        Timber.d(message);
     }
 
     public static void d(String TAG, String message, Exception e) {
-        Log.d(TAG, message, e);
-        appendLog("D: " + TAG + " : " + message + " Exception : " + e.getStackTrace());
+        Timber.d(e, message);
     }
 
     public static void e(String TAG, String message) {
-        Log.e(TAG, message);
-        appendLog("E: " + TAG + " : " + message);
+        Timber.d(message);
     }
 
     public static void e(String TAG, String message, Throwable e) {
-        Log.e(TAG, message, e);
-        appendLog("E: " + TAG + " : " + message + " Exception : " + e.getStackTrace());
+        Timber.e(e, message);
     }
 
     public static void v(String TAG, String message) {
-        Log.v(TAG, message);
-        appendLog("V: " + TAG + " : " + message);
+        Timber.v(message);
     }
 
     public static void w(String TAG, String message) {
-        Log.w(TAG, message);
-        appendLog("W: " + TAG + " : " + message);
+        Timber.w(message);
     }
 
-    /**
-     * Start doing logging
-     *
-     * @param storagePath : directory for keeping logs
-     */
-    synchronized public static void startLogging(String storagePath) {
-        String logPath = storagePath + File.separator + mOwncloudDataFolderLog + File.separator + LOG_FOLDER_NAME;
-        mFolder = new File(logPath);
-        mLogFile = new File(mFolder + File.separator + mLogFileNames[0]);
-
-        boolean isFileCreated = false;
-
-        if (!mFolder.exists()) {
-            mFolder.mkdirs();
-            isFileCreated = true;
-            Log.d("LOG_OC", "Log file created");
-        }
-
-        try {
-
-            // Create the current log file if does not exist
-            mLogFile.createNewFile();
-            mBuf = new BufferedWriter(new FileWriter(mLogFile, true));
-            isEnabled = true;
-
-            if (isFileCreated) {
-                appendPhoneInfo();
-            }
-
-        } catch (IOException e) {
-            e.printStackTrace();
-        } finally {
-            if (mBuf != null) {
-                try {
-                    mBuf.close();
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
-        }
+    public static void startLogging(String storagePath) {
+        LoggingHelper.INSTANCE.startLogging(
+                new File(storagePath+ File.separator + mOwncloudDataFolderLog), mOwncloudDataFolderLog);
     }
 
-    synchronized public static void stopLogging() {
-        try {
-            if (mBuf != null) {
-                mBuf.close();
-            }
-            isEnabled = false;
-
-            mLogFile = null;
-            mFolder = null;
-            mBuf = null;
-            isMaxFileSizeReached = false;
-
-        } catch (IOException e) {
-            // Because we are stopping logging, we only log to Android console.
-            Log.e("OC_Log", "Closing log file failed: ", e);
-        } catch (Exception e) {
-            // This catch should never fire because we do null check on mBuf.
-            // But just for the sake of stability let's log this odd situation.
-            // Because we are stopping logging, we only log to Android console.
-            Log.e("OC_Log", "Stopping logging failed: ", e);
-        }
+    public static void stopLogging() {
+        LoggingHelper.INSTANCE.stopLogging();
     }
 
-    /**
-     * Delete history logging
-     */
-    public static void deleteHistoryLogging() {
-        File folderLogs = new File(mFolder + File.separator);
-        if (folderLogs.isDirectory()) {
-            String[] myFiles = folderLogs.list();
-            for (String fileName : myFiles) {
-                File fileInFolder = new File(folderLogs, fileName);
-                Log_OC.d("delete file", fileInFolder.getAbsoluteFile() + " " + fileInFolder.delete());
-            }
-        }
-    }
-
-    /**
-     * Append the info of the device
-     */
-    private static void appendPhoneInfo() {
-        appendLog("Model : " + android.os.Build.MODEL);
-        appendLog("Brand : " + android.os.Build.BRAND);
-        appendLog("Product : " + android.os.Build.PRODUCT);
-        appendLog("Device : " + android.os.Build.DEVICE);
-        appendLog("Version-Codename : " + android.os.Build.VERSION.CODENAME);
-        appendLog("Version-Release : " + android.os.Build.VERSION.RELEASE);
-    }
-
-    /**
-     * Append to the log file the info passed
-     *
-     * @param text : text for adding to the log file
-     */
-    synchronized private static void appendLog(String text) {
-
-        if (isEnabled) {
-
-            if (isMaxFileSizeReached) {
-
-                // Move current log file info to another file (old logs)
-                File olderFile = new File(mFolder + File.separator + mLogFileNames[1]);
-                if (mLogFile.exists()) {
-                    mLogFile.renameTo(olderFile);
-                }
-
-                // Construct a new file for current log info
-                mLogFile = new File(mFolder + File.separator + mLogFileNames[0]);
-                isMaxFileSizeReached = false;
-            }
-
-            String timeStamp = new SimpleDateFormat(SIMPLE_DATE_FORMAT, Locale.ENGLISH).format(Calendar.getInstance().getTime());
-
-            try {
-                mBuf = new BufferedWriter(new FileWriter(mLogFile, true));
-                mBuf.newLine();
-                mBuf.write(timeStamp + " " + text);
-            } catch (IOException e) {
-                e.printStackTrace();
-            } finally {
-                try {
-                    mBuf.close();
-                } catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
-
-            // Check if current log file size is bigger than the max file size defined
-            if (mLogFile.length() > MAX_FILE_SIZE) {
-                isMaxFileSizeReached = true;
-            }
-        }
-    }
-
-    public static String[] getLogFileNames() {
-        return mLogFileNames;
-    }
 }

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/utils/LoggingHelper.kt
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/utils/LoggingHelper.kt
@@ -1,0 +1,24 @@
+package com.owncloud.android.lib.common.utils
+
+import info.hannes.timber.FileLoggingTree
+import info.hannes.timber.fileLoggingTree
+import timber.log.Timber
+import java.io.File
+
+object LoggingHelper {
+
+    fun startLogging(directory: File, storagePath: String) {
+        Timber.forest().fileLoggingTree()?.let {
+            Timber.forest().drop(Timber.forest().indexOf(it))
+        }
+        if (!directory.exists())
+            directory.mkdirs()
+        Timber.plant(FileLoggingTree(directory, filename = storagePath, delegator = Log_OC::class.java))
+    }
+
+    fun stopLogging() {
+        Timber.forest().fileLoggingTree()?.let {
+            Timber.forest().drop(Timber.forest().indexOf(it))
+        }
+    }
+}


### PR DESCRIPTION
It's about to change logging from self-made to [Timber](https://github.com/JakeWharton/timber).
All is encapsulated with a logging lib which I use in several places.
**I kept to old Log_OC** , to easy migrate and do not touch all files. Especially when you do a huge refactoring

One major advantage for developers:
Before:

![image](https://user-images.githubusercontent.com/3314607/68023509-94575480-fca7-11e9-8a48-ea105420bd25.png)


**NEW**:  you can **click log log line** and jump direct to code ! You see the linenumber as well

![image](https://user-images.githubusercontent.com/3314607/68023537-b2bd5000-fca7-11e9-96c2-d5d10739731b.png)

