### PR TITLE
Finish remove Android 4.4 support

### DIFF
--- a/sample_client/build.gradle
+++ b/sample_client/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 28
     }
 


### PR DESCRIPTION
Your Bitrise is a black box and I don't know what you test. 
But I know, you don't run
` ./gradlew clean build`

otherwise you will see

<img width="826" alt="image" src="https://user-images.githubusercontent.com/3314607/71150168-045a7380-2231-11ea-8bc0-3577125fdb97.png">

Needed for: https://github.com/owncloud/android/pull/2768