### PR TITLE
Use constants instead of hardcoded values for dir mimetypes

### DIFF
--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/files/FileUtils.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/files/FileUtils.java
@@ -30,6 +30,8 @@ import java.io.File;
 
 public class FileUtils {
     public static final String FINAL_CHUNKS_FILE = ".file";
+    public static final String MIME_DIR = "DIR";
+    public static final String MIME_DIR_UNIX = "httpd/unix-directory";
 
     static String getParentPath(String remotePath) {
         String parentPath = new File(remotePath).getParent();

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/files/RemoteFile.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/files/RemoteFile.java
@@ -29,7 +29,17 @@ import android.os.Parcelable;
 
 import at.bitfire.dav4jvm.Property;
 import at.bitfire.dav4jvm.Response;
-import at.bitfire.dav4jvm.property.*;
+import at.bitfire.dav4jvm.property.CreationDate;
+import at.bitfire.dav4jvm.property.GetContentLength;
+import at.bitfire.dav4jvm.property.GetContentType;
+import at.bitfire.dav4jvm.property.GetETag;
+import at.bitfire.dav4jvm.property.GetLastModified;
+import at.bitfire.dav4jvm.property.OCId;
+import at.bitfire.dav4jvm.property.OCPermissions;
+import at.bitfire.dav4jvm.property.OCPrivatelink;
+import at.bitfire.dav4jvm.property.OCSize;
+import at.bitfire.dav4jvm.property.QuotaAvailableBytes;
+import at.bitfire.dav4jvm.property.QuotaUsedBytes;
 
 import java.io.File;
 import java.io.Serializable;
@@ -83,7 +93,8 @@ public class RemoteFile implements Parcelable, Serializable {
     /**
      * Create new {@link RemoteFile} with given path.
      * <p>
-     * The path received must be URL-decoded. Path separator must be File.separator, and it must be the first character in 'path'.
+     * The path received must be URL-decoded. Path separator must be File.separator, and it must be the first
+     * character in 'path'.
      *
      * @param path The remote path of the file.
      */
@@ -95,7 +106,7 @@ public class RemoteFile implements Parcelable, Serializable {
         mRemotePath = path;
         mCreationTimestamp = 0;
         mLength = 0;
-        mMimeType = "DIR";
+        mMimeType = FileUtils.MIME_DIR;
         mQuotaUsedBytes = BigDecimal.ZERO;
         mQuotaAvailableBytes = BigDecimal.ZERO;
         mPrivateLink = null;
@@ -154,6 +165,14 @@ public class RemoteFile implements Parcelable, Serializable {
         readFromParcel(source);
     }
 
+    /**
+     * Use this to find out if this file is a folder.
+     *
+     * @return true if it is a folder
+     */
+    public boolean isFolder() {
+        return mMimeType != null && (mMimeType.equals(FileUtils.MIME_DIR) || mMimeType.equals(FileUtils.MIME_DIR_UNIX));
+    }
 
     /**
      * Getters and Setters


### PR DESCRIPTION
Fixes a problem where file size was 0 due to hardcoded mimetypes.

Needed for https://github.com/owncloud/android/pull/3040

oc10 -> "DIR"
ocis -> "httpd/unix-directory"