### PR TITLE
Make some fields not mandatory in discovery response

### DIFF
--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/oauth/responses/OIDCDiscoveryResponse.kt
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/oauth/responses/OIDCDiscoveryResponse.kt
@@ -31,13 +31,13 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class OIDCDiscoveryResponse(
     val authorization_endpoint: String,
-    val check_session_iframe: String,
-    val end_session_endpoint: String,
+    val check_session_iframe: String?,
+    val end_session_endpoint: String?,
     val issuer: String,
-    val registration_endpoint: String,
+    val registration_endpoint: String?,
     val response_types_supported: List<String>,
-    val scopes_supported: List<String>,
+    val scopes_supported: List<String>?,
     val token_endpoint: String,
-    val token_endpoint_auth_methods_supported: List<String>,
-    val userinfo_endpoint: String,
+    val token_endpoint_auth_methods_supported: List<String>?,
+    val userinfo_endpoint: String?,
 )


### PR DESCRIPTION
`registration_endpoint` is mandatory at the moment but it should not according to https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata

It should fix a problem that happens when `registration_endpoint` is not retrieved in the discovery.

App: https://github.com/owncloud/android/pull/3202