### PR TITLE
add error log when content-length not equal to transfaired bytes

### DIFF
--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/files/DownloadRemoteFileOperation.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/files/DownloadRemoteFileOperation.java
@@ -159,6 +159,8 @@ public class DownloadRemoteFileOperation extends RemoteOperation {
                     }
 
                 } else {
+                    Timber.e("Content-Length not equal to transferred bytes.");
+                    Timber.d("totalToTransfer = %d, transferred = %d", totalToTransfer, transferred);
                     client.exhaustResponse(mGet.getResponseBodyAsStream());
                     // TODO some kind of error control!
                 }


### PR DESCRIPTION
fix for issue: https://github.com/owncloud/android-library/issues/424