### PR TITLE
Feature/add stetho

### DIFF
--- a/owncloudComLibrary/build.gradle
+++ b/owncloudComLibrary/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.robolectric:robolectric:4.7.3'
+    debugImplementation 'com.facebook.stetho:stetho-okhttp3:1.5.1'
 }
 
 android {

--- a/owncloudComLibrary/src/debug/java/com/owncloud/android/lib/common/http/DebugInterceptorFactory.kt
+++ b/owncloudComLibrary/src/debug/java/com/owncloud/android/lib/common/http/DebugInterceptorFactory.kt
@@ -1,0 +1,9 @@
+package com.owncloud.android.lib.common.http
+
+import com.facebook.stetho.okhttp3.StethoInterceptor
+
+class DebugInterceptorFactory {
+    companion object {
+        fun getInterceptor() = StethoInterceptor()
+    }
+}

--- a/owncloudComLibrary/src/debug/java/com/owncloud/android/lib/common/http/DebugInterceptorFactory.kt
+++ b/owncloudComLibrary/src/debug/java/com/owncloud/android/lib/common/http/DebugInterceptorFactory.kt
@@ -1,9 +1,30 @@
+/* ownCloud Android Library is available under MIT license
+ *   Copyright (C) 2020 ownCloud GmbH.
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ *   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ *   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ */
+
 package com.owncloud.android.lib.common.http
 
 import com.facebook.stetho.okhttp3.StethoInterceptor
 
-class DebugInterceptorFactory {
-    companion object {
-        fun getInterceptor() = StethoInterceptor()
-    }
+object DebugInterceptorFactory {
+    fun getInterceptor() = StethoInterceptor()
 }

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/DummyInterceptor.kt
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/DummyInterceptor.kt
@@ -1,0 +1,10 @@
+package com.owncloud.android.lib.common.http
+
+import okhttp3.Interceptor
+import okhttp3.Response
+
+class DummyInterceptor : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        return chain.proceed(chain.request())
+    }
+}

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/DummyInterceptor.kt
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/DummyInterceptor.kt
@@ -1,10 +1,31 @@
+/* ownCloud Android Library is available under MIT license
+ *   Copyright (C) 2020 ownCloud GmbH.
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ *   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ *   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ *
+ */
+
 package com.owncloud.android.lib.common.http
 
 import okhttp3.Interceptor
-import okhttp3.Response
 
 class DummyInterceptor : Interceptor {
-    override fun intercept(chain: Interceptor.Chain): Response {
-        return chain.proceed(chain.request())
-    }
+    override fun intercept(chain: Interceptor.Chain) = chain.proceed(chain.request())
 }

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/HttpClient.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/HttpClient.java
@@ -58,6 +58,7 @@ public class HttpClient {
     private static Context sContext;
     private static HashMap<String, List<Cookie>> sCookieStore = new HashMap<>();
     private static LogInterceptor sLogInterceptor;
+    private static DebugInterceptor sDebugInterceptor;
 
     public static OkHttpClient getOkHttpClient() {
         if (sOkHttpClient == null) {
@@ -111,6 +112,7 @@ public class HttpClient {
                                                      CookieJar cookieJar) {
         return new OkHttpClient.Builder()
                 .addNetworkInterceptor(getLogInterceptor())
+                .addNetworkInterceptor(DebugInterceptorFactory.Companion.getInterceptor())
                 .protocols(Collections.singletonList(Protocol.HTTP_1_1))
                 .readTimeout(HttpConstants.DEFAULT_DATA_TIMEOUT, TimeUnit.MILLISECONDS)
                 .writeTimeout(HttpConstants.DEFAULT_DATA_TIMEOUT, TimeUnit.MILLISECONDS)
@@ -127,6 +129,13 @@ public class HttpClient {
             sLogInterceptor = new LogInterceptor();
         }
         return sLogInterceptor;
+    }
+
+    public static DebugInterceptor getDebugInterceptor() {
+        if (sDebugInterceptor == null) {
+            sDebugInterceptor = new DebugInterceptor();
+        }
+        return sDebugInterceptor;
     }
 
     public static List<Cookie> getCookiesFromUrl(HttpUrl httpUrl) {

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/HttpClient.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/HttpClient.java
@@ -31,6 +31,7 @@ import com.owncloud.android.lib.common.network.NetworkUtils;
 import okhttp3.Cookie;
 import okhttp3.CookieJar;
 import okhttp3.HttpUrl;
+import okhttp3.Interceptor;
 import okhttp3.OkHttpClient;
 import okhttp3.Protocol;
 import okhttp3.TlsVersion;
@@ -58,7 +59,7 @@ public class HttpClient {
     private static Context sContext;
     private static HashMap<String, List<Cookie>> sCookieStore = new HashMap<>();
     private static LogInterceptor sLogInterceptor;
-    private static DebugInterceptor sDebugInterceptor;
+    private static Interceptor sDebugInterceptor;
 
     public static OkHttpClient getOkHttpClient() {
         if (sOkHttpClient == null) {
@@ -129,13 +130,6 @@ public class HttpClient {
             sLogInterceptor = new LogInterceptor();
         }
         return sLogInterceptor;
-    }
-
-    public static DebugInterceptor getDebugInterceptor() {
-        if (sDebugInterceptor == null) {
-            sDebugInterceptor = new DebugInterceptor();
-        }
-        return sDebugInterceptor;
     }
 
     public static List<Cookie> getCookiesFromUrl(HttpUrl httpUrl) {

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/HttpClient.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/HttpClient.java
@@ -113,7 +113,7 @@ public class HttpClient {
                                                      CookieJar cookieJar) {
         return new OkHttpClient.Builder()
                 .addNetworkInterceptor(getLogInterceptor())
-                .addNetworkInterceptor(DebugInterceptorFactory.Companion.getInterceptor())
+                .addNetworkInterceptor(DebugInterceptorFactory.INSTANCE.getInterceptor())
                 .protocols(Collections.singletonList(Protocol.HTTP_1_1))
                 .readTimeout(HttpConstants.DEFAULT_DATA_TIMEOUT, TimeUnit.MILLISECONDS)
                 .writeTimeout(HttpConstants.DEFAULT_DATA_TIMEOUT, TimeUnit.MILLISECONDS)

--- a/owncloudComLibrary/src/release/java/com/owncloud/android/lib/common/http/DebugInterceptorFactory.kt
+++ b/owncloudComLibrary/src/release/java/com/owncloud/android/lib/common/http/DebugInterceptorFactory.kt
@@ -1,0 +1,7 @@
+package com.owncloud.android.lib.common.http
+
+class DebugInterceptorFactory {
+    companion object {
+        fun getInterceptor() = DummyInterceptor()
+    }
+}

--- a/owncloudComLibrary/src/release/java/com/owncloud/android/lib/common/http/DebugInterceptorFactory.kt
+++ b/owncloudComLibrary/src/release/java/com/owncloud/android/lib/common/http/DebugInterceptorFactory.kt
@@ -1,7 +1,29 @@
+/* ownCloud Android Library is available under MIT license
+ *   Copyright (C) 2020 ownCloud GmbH.
+ *
+ *   Permission is hereby granted, free of charge, to any person obtaining a copy
+ *   of this software and associated documentation files (the "Software"), to deal
+ *   in the Software without restriction, including without limitation the rights
+ *   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *   copies of the Software, and to permit persons to whom the Software is
+ *   furnished to do so, subject to the following conditions:
+ *
+ *   The above copyright notice and this permission notice shall be included in
+ *   all copies or substantial portions of the Software.
+ *
+ *   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ *   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ *   BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ *   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ *   CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *   THE SOFTWARE.
+ *
+ */
+
 package com.owncloud.android.lib.common.http
 
-class DebugInterceptorFactory {
-    companion object {
-        fun getInterceptor() = DummyInterceptor()
-    }
+object DebugInterceptorFactory {
+    fun getInterceptor() = DummyInterceptor()
 }


### PR DESCRIPTION
APP: https://github.com/owncloud/android/pull/3568

This will add facebook stetho and leak canary permanently to the debug version of the app. This makes debuging network requests easier as requests can be viewed all the time without having to use mitm proxy and therefore explicitly change the phone configuration.
These two things will not be pressent in the release build.