### PR TITLE
Fix unexpected end of stream when connecting with server

### DIFF
--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/methods/HttpBaseMethod.kt
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/methods/HttpBaseMethod.kt
@@ -45,7 +45,7 @@ abstract class HttpBaseMethod constructor(url: URL) {
     var call: Call? = null
 
     var followRedirects: Boolean = true
-    var retryOnConnectionFailure: Boolean = false
+    var retryOnConnectionFailure: Boolean = true
     var connectionTimeoutVal: Long? = null
     var connectionTimeoutUnit: TimeUnit? = null
     var readTimeoutVal: Long? = null
@@ -62,8 +62,8 @@ abstract class HttpBaseMethod constructor(url: URL) {
     @Throws(Exception::class)
     open fun execute(httpClient: HttpClient): Int {
         val okHttpClient = httpClient.okHttpClient.newBuilder().apply {
-            retryOnConnectionFailure.let { retryOnConnectionFailure(it) }
-            followRedirects.let { followRedirects(it) }
+            retryOnConnectionFailure(retryOnConnectionFailure)
+            followRedirects(followRedirects)
             readTimeoutUnit?.let { unit ->
                 readTimeoutVal?.let { readTimeout(it, unit) }
             }


### PR DESCRIPTION
Fix https://github.com/owncloud/android/issues/3647

``` Create RemoteOperationResult from exception.
     Message: IOException: unexpected end of stream on ...
     Stacktrace: java.io.IOException: unexpected end of stream on...
        at okhttp3.internal.http1.Http1ExchangeCodec.readResponseHeaders(Http1ExchangeCodec.kt:202)
        at okhttp3.internal.connection.Exchange.readResponseHeaders(Exchange.kt:106)
        at okhttp3.internal.http.CallServerInterceptor.intercept(CallServerInterceptor.kt:79)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:100)
        at com.facebook.stetho.okhttp3.StethoInterceptor.intercept(StethoInterceptor.java:54)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:100)
        at com.owncloud.android.lib.common.http.LogInterceptor.intercept(LogInterceptor.kt:49)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:100)
        at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.kt:34)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:100)
        at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.kt:82)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:100)
        at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.kt:83)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:100)
        at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.kt:76)
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:100)
        at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:197)
        at okhttp3.internal.connection.RealCall.execute(RealCall.kt:148)
        at com.owncloud.android.lib.common.http.methods.nonwebdav.HttpMethod.onExecute(HttpMethod.kt:44)
        at com.owncloud.android.lib.common.http.methods.nonwebdav.GetMethod.onExecute(GetMethod.kt:41)
        at com.owncloud.android.lib.common.http.methods.HttpBaseMethod.execute(HttpBaseMethod.kt:75)
        at com.owncloud.android.lib.common.OwnCloudClient.saveExecuteHttpMethod(OwnCloudClient.java:138)
        at com.owncloud.android.lib.common.OwnCloudClient.executeHttpMethod(OwnCloudClient.java:108)
        at com.owncloud.android.lib.resources.files.DownloadRemoteFileOperation.downloadFile(DownloadRemoteFileOperation.java:105)
        at com.owncloud.android.lib.resources.files.DownloadRemoteFileOperation.run(DownloadRemoteFileOperation.java:82)
        at com.owncloud.android.lib.common.operations.RemoteOperation.runOperation(RemoteOperation.java:264)
        at com.owncloud.android.lib.common.operations.RemoteOperation.execute(RemoteOperation.java:229)
        at com.owncloud.android.operations.DownloadFileOperation.run(DownloadFileOperation.java:153)
        at com.owncloud.android.lib.common.operations.RemoteOperation.runOperation(RemoteOperation.java:264)
        at com.owncloud.android.lib.common.operations.RemoteOperation.execute(RemoteOperation.java:229)
        at com.owncloud.android.files.services.FileDownloader.downloadFile(FileDownloader.java:442)
        at com.owncloud.android.files.services.FileDownloader.access$400(FileDownloader.java:73)
        at com.owncloud.android.files.services.FileDownloader$ServiceHandler.handleMessage(FileDownloader.java:390)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loop(Looper.java:246)
        at android.os.HandlerThread.run(HandlerThread.java:67)
     Caused by: java.io.EOFException: \n not found: limit=0 content=…
        at okio.RealBufferedSource.readUtf8LineStrict(RealBufferedSource.kt:332)
        at okhttp3.internal.http1.HeadersReader.readLine(HeadersReader.kt:29)
        at okhttp3.internal.http1.Http1ExchangeCodec.readResponseHeaders(Http1ExchangeCodec.kt:178)
        at okhttp3.internal.connection.Exchange.readResponseHeaders(Exchange.kt:106) 
        at okhttp3.internal.http.CallServerInterceptor.intercept(CallServerInterceptor.kt:79) 
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:100) 
        at com.facebook.stetho.okhttp3.StethoInterceptor.intercept(StethoInterceptor.java:54) 
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:100) 
        at com.owncloud.android.lib.common.http.LogInterceptor.intercept(LogInterceptor.kt:49) 
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:100) 
        at okhttp3.internal.connection.ConnectInterceptor.intercept(ConnectInterceptor.kt:34) 
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:100) 
        at okhttp3.internal.cache.CacheInterceptor.intercept(CacheInterceptor.kt:82) 
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:100) 
        at okhttp3.internal.http.BridgeInterceptor.intercept(BridgeInterceptor.kt:83) 
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:100) 
        at okhttp3.internal.http.RetryAndFollowUpInterceptor.intercept(RetryAndFollowUpInterceptor.kt:76) 
        at okhttp3.internal.http.RealInterceptorChain.proceed(RealInterceptorChain.kt:100) 
        at okhttp3.internal.connection.RealCall.getResponseWithInterceptorChain$okhttp(RealCall.kt:197) 
        at okhttp3.internal.connection.RealCall.execute(RealCall.kt:148) 
        at com.owncloud.android.lib.common.http.methods.nonwebdav.HttpMethod.onExecute(HttpMethod.kt:44) 
        at com.owncloud.android.lib.common.http.methods.nonwebdav.GetMethod.onExecute(GetMethod.kt:41) 
        at com.owncloud.android.lib.common.http.methods.HttpBaseMethod.execute(HttpBaseMethod.kt:75) 
        at com.owncloud.android.lib.common.OwnCloudClient.saveExecuteHttpMethod(OwnCloudClient.java:138) 
        at com.owncloud.android.lib.common.OwnCloudClient.executeHttpMethod(OwnCloudClient.java:108) 
        at com.owncloud.android.lib.resources.files.DownloadRemoteFileOperation.downloadFile(DownloadRemoteFileOperation.java:105) 
        at com.owncloud.android.lib.resources.files.DownloadRemoteFileOperation.run(DownloadRemoteFileOperation.java:82) 
        at com.owncloud.android.lib.common.operations.RemoteOperation.runOperation(RemoteOperation.java:264) 
        at com.owncloud.android.lib.common.operations.RemoteOperation.execute(RemoteOperation.java:229) 
        at com.owncloud.android.operations.DownloadFileOperation.run(DownloadFileOperation.java:153) 
        at com.owncloud.android.lib.common.operations.RemoteOperation.runOperation(RemoteOperation.java:264) 
        at com.owncloud.android.lib.common.operations.RemoteOperation.execute(RemoteOperation.java:229) 
        at com.owncloud.android.files.services.FileDownloader.downloadFile(FileDownloader.java:442) 
        at com.owncloud.android.files.services.FileDownloader.access$400(FileDownloader.java:73) 
        at com.owncloud.android.files.services.FileDownloader$ServiceHandler.handleMessage(FileDownloader.java:390) 
        at android.os.Handler.dispatchMessage(Handler.java:106) 
        at android.os.Looper.loop(Looper.java:246) 
        at android.os.HandlerThread.run(HandlerThread.java:67) ```