### PR TITLE
Retrieve share type directly within the propfind

### DIFF
--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/methods/webdav/properties/OCShareTypes.kt
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/methods/webdav/properties/OCShareTypes.kt
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2020 ownCloud GmbH.
+ *   Copyright (C) 2022 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal
@@ -21,17 +21,24 @@
  *   THE SOFTWARE.
  *
  */
-package com.owncloud.android.lib.common.http.methods.webdav
+package com.owncloud.android.lib.common.http.methods.webdav.properties
 
 import at.bitfire.dav4jvm.Property
-import at.bitfire.dav4jvm.PropertyUtils.getAllPropSet
-import at.bitfire.dav4jvm.PropertyUtils.getQuotaPropset
-import com.owncloud.android.lib.common.http.methods.webdav.properties.OCShareTypes
+import at.bitfire.dav4jvm.XmlUtils
+import org.xmlpull.v1.XmlPullParser
 
-object DavUtils {
-    @JvmStatic val allPropset: Array<Property.Name>
-        get() = getAllPropSet().plus(OCShareTypes.NAME)
+class OCShareTypes : ShareTypeListProperty() {
 
-    val quotaPropSet: Array<Property.Name>
-        get() = getQuotaPropset()
+    class Factory : ShareTypeListProperty.Factory() {
+
+        override fun create(parser: XmlPullParser) =
+            create(parser, OCShareTypes())
+
+        override fun getName(): Property.Name = NAME
+    }
+
+    companion object {
+        @JvmField
+        val NAME = Property.Name(XmlUtils.NS_OWNCLOUD, "share-types")
+    }
 }

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/methods/webdav/properties/ShareTypeListProperty.kt
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/common/http/methods/webdav/properties/ShareTypeListProperty.kt
@@ -1,5 +1,5 @@
 /* ownCloud Android Library is available under MIT license
- *   Copyright (C) 2020 ownCloud GmbH.
+ *   Copyright (C) 2022 ownCloud GmbH.
  *
  *   Permission is hereby granted, free of charge, to any person obtaining a copy
  *   of this software and associated documentation files (the "Software"), to deal
@@ -21,17 +21,26 @@
  *   THE SOFTWARE.
  *
  */
-package com.owncloud.android.lib.common.http.methods.webdav
+package com.owncloud.android.lib.common.http.methods.webdav.properties
 
 import at.bitfire.dav4jvm.Property
-import at.bitfire.dav4jvm.PropertyUtils.getAllPropSet
-import at.bitfire.dav4jvm.PropertyUtils.getQuotaPropset
-import com.owncloud.android.lib.common.http.methods.webdav.properties.OCShareTypes
+import at.bitfire.dav4jvm.PropertyFactory
+import at.bitfire.dav4jvm.XmlUtils
+import org.xmlpull.v1.XmlPullParser
+import java.util.LinkedList
 
-object DavUtils {
-    @JvmStatic val allPropset: Array<Property.Name>
-        get() = getAllPropSet().plus(OCShareTypes.NAME)
+abstract class ShareTypeListProperty : Property {
 
-    val quotaPropSet: Array<Property.Name>
-        get() = getQuotaPropset()
+    val shareTypes = LinkedList<String>()
+
+    override fun toString() = "share types =[" + shareTypes.joinToString(", ") + "]"
+
+    abstract class Factory : PropertyFactory {
+
+        fun create(parser: XmlPullParser, list: ShareTypeListProperty): ShareTypeListProperty {
+            XmlUtils.readTextPropertyList(parser, Property.Name(XmlUtils.NS_OWNCLOUD, "share-type"), list.shareTypes)
+            return list
+        }
+
+    }
 }

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/files/ReadRemoteFolderOperation.java
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/files/ReadRemoteFolderOperation.java
@@ -24,6 +24,7 @@
 
 package com.owncloud.android.lib.resources.files;
 
+import at.bitfire.dav4jvm.PropertyRegistry;
 import at.bitfire.dav4jvm.Response;
 import com.owncloud.android.lib.common.OwnCloudClient;
 import com.owncloud.android.lib.common.accounts.AccountUtils;
@@ -31,6 +32,7 @@ import com.owncloud.android.lib.common.http.HttpConstants;
 import com.owncloud.android.lib.common.http.methods.webdav.DavConstants;
 import com.owncloud.android.lib.common.http.methods.webdav.DavUtils;
 import com.owncloud.android.lib.common.http.methods.webdav.PropfindMethod;
+import com.owncloud.android.lib.common.http.methods.webdav.properties.OCShareTypes;
 import com.owncloud.android.lib.common.network.WebdavUtils;
 import com.owncloud.android.lib.common.operations.RemoteOperation;
 import com.owncloud.android.lib.common.operations.RemoteOperationResult;
@@ -72,6 +74,7 @@ public class ReadRemoteFolderOperation extends RemoteOperation<ArrayList<RemoteF
         RemoteOperationResult<ArrayList<RemoteFile>> result = null;
 
         try {
+            PropertyRegistry.INSTANCE.register(OCShareTypes.Factory.class.newInstance());
             PropfindMethod propfindMethod = new PropfindMethod(
                     new URL(client.getUserFilesWebDavUri() + WebdavUtils.encodePath(mRemotePath)),
                     DavConstants.DEPTH_1,


### PR DESCRIPTION
Add a new property to the propfind. So that, we can get if the file is shared directly in just one request.

App: https://github.com/owncloud/android/pull/3711