### PR TITLE
[New arch] Chunking bugfixing

### DIFF
--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/files/chunks/ChunkedUploadFromFileSystemOperation.kt
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/files/chunks/ChunkedUploadFromFileSystemOperation.kt
@@ -116,7 +116,7 @@ class ChunkedUploadFromFileSystemOperation(
     }
 
     companion object {
-        const val CHUNK_SIZE = 1_024_000L
+        const val CHUNK_SIZE = 10_240_000L // 10 MB
         private const val LAST_CHUNK_TIMEOUT = 900_000 // 15 mins.
     }
 }


### PR DESCRIPTION
When doing a manual content URI upload, now files are copied to local storage before uploading them.

App PR: https://github.com/owncloud/android/pull/3763