### PR TITLE
Unsharing wont return anything anymore since result object was not used

### DIFF
--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/shares/services/ShareService.kt
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/shares/services/ShareService.kt
@@ -58,5 +58,5 @@ interface ShareService : Service {
         publicUpload: Boolean
     ): RemoteOperationResult<ShareResponse>
 
-    fun deleteShare(remoteId: String): RemoteOperationResult<ShareResponse>
+    fun deleteShare(remoteId: String): RemoteOperationResult<Unit>
 }

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/shares/services/implementation/OCShareService.kt
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/shares/services/implementation/OCShareService.kt
@@ -36,8 +36,7 @@ import com.owncloud.android.lib.resources.shares.ShareType
 import com.owncloud.android.lib.resources.shares.UpdateRemoteShareOperation
 import com.owncloud.android.lib.resources.shares.services.ShareService
 
-class OCShareService(override val client: OwnCloudClient) :
-    ShareService {
+class OCShareService(override val client: OwnCloudClient) : ShareService {
     override fun getShares(
         remoteFilePath: String,
         reshares: Boolean,
@@ -90,7 +89,7 @@ class OCShareService(override val client: OwnCloudClient) :
             this.retrieveShareDetails = true
         }.execute(client)
 
-    override fun deleteShare(remoteId: String): RemoteOperationResult<ShareResponse> =
+    override fun deleteShare(remoteId: String): RemoteOperationResult<Unit> =
         RemoveRemoteShareOperation(
             remoteId
         ).execute(client)


### PR DESCRIPTION
There is no need to parse the response anymore. The app is not using that data, just checks if it was successful or not.

oC10 returned an empty list
oCIS returns an object

That's why it was not working properly on oCIS