### PR TITLE
Bump kotlin version to 1.8.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        orgJetbrainsKotlin = '1.7.20'
+        orgJetbrainsKotlin = '1.8.10'
         comSquareupMoshi = '1.14.0'
     }
 
@@ -11,7 +11,7 @@ buildscript {
     }
     dependencies {
         classpath "org.jlleitschuh.gradle:ktlint-gradle:11.1.0"
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:7.4.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$orgJetbrainsKotlin"
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/owncloudComLibrary/build.gradle
+++ b/owncloudComLibrary/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'kotlin-parcelize'
 
 dependencies {
     api 'com.squareup.okhttp3:okhttp:4.6.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$orgJetbrainsKotlin"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$orgJetbrainsKotlin"
     api 'com.gitlab.ownclouders:dav4android:oc_support_2.1.5'
     api 'com.github.AppDevNext.Logcat:LogcatCore:2.2.2'
 


### PR DESCRIPTION
Bump kotlin version to 1.8.10 

Release details: https://kotlinlang.org/docs/whatsnew18.html#ide-support

`kotlin-stdlib-jdk7` and `kotlin-stdlib-jdk8`  have been merged into `kotlin-stdlib`

App PR: https://github.com/owncloud/android/pull/3911