### PR TITLE
[TECHNICAL] Bump target sdk to 33

### DIFF
--- a/owncloudComLibrary/build.gradle
+++ b/owncloudComLibrary/build.gradle
@@ -26,7 +26,7 @@ android {
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 31
+        targetSdkVersion 33
     }
 
     lint {


### PR DESCRIPTION
Bump target sdk to 33, nothing relevant at library side

App: https://github.com/owncloud/android/pull/3972