### PR TITLE
Remove permission parsing from spaces. 

### DIFF
--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/spaces/responses/SpacesResponse.kt
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/spaces/responses/SpacesResponse.kt
@@ -61,7 +61,6 @@ data class QuotaResponse(
 data class RootResponse(
     val eTag: String?,
     val id: String,
-    val permissions: List<PermissionResponse>?,
     val webDavUrl: String,
     val deleted: DeleteResponse?,
 )
@@ -89,36 +88,9 @@ data class FileResponse(
 )
 
 @JsonClass(generateAdapter = true)
-data class IdentityPermissionResponse(
-    val id: String,
-    val displayName: String?,
-)
-
-@JsonClass(generateAdapter = true)
-data class GrantedToIdentitiesResponse(
-    val user: IdentityPermissionResponse?,
-    val group: IdentityPermissionResponse?,
-)
-
-@JsonClass(generateAdapter = true)
 data class DeleteResponse(
     val state: String,
 )
-
-@JsonClass(generateAdapter = true)
-data class PermissionResponse(
-    val grantedTo: List<GrantedToIdentitiesResponse>?,
-    val grantedToIdentities: List<GrantedToIdentitiesResponse>?,
-    val roles: List<String>,
-) {
-    /**
-     * Supports api renaming from grantedTo to grantedToIdentities on v1.0.1
-     * https://github.com/owncloud/libre-graph-api/releases/tag/v1.0.1
-     */
-    fun getGrantedToIdentitiesResponse(): List<GrantedToIdentitiesResponse> {
-        return grantedToIdentities ?: grantedTo ?: throw IllegalArgumentException("Permissions not granted to anyone")
-    }
-}
 
 @JsonClass(generateAdapter = true)
 data class SpecialFolderResponse(


### PR DESCRIPTION
Permissions will be handled via WebDav. So no need to maintain this parsing.