### PR TITLE
Update WebFinger flow

### DIFF
--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/webfinger/GetInstancesViaWebFingerOperation.kt
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/webfinger/GetInstancesViaWebFingerOperation.kt
@@ -75,13 +75,17 @@ class GetInstancesViaWebFingerOperation(
         val response = parseResponse(rawResponse)
         Timber.d("Successful WebFinger request: $response")
         val operationResult = RemoteOperationResult<List<String>>(RemoteOperationResult.ResultCode.OK)
-        operationResult.data = response.links.map { it.href }
+        operationResult.data = response.links?.map { it.href } ?: listOf()
         return operationResult
     }
 
     override fun run(client: OwnCloudClient): RemoteOperationResult<List<String>> {
         val requestUri = buildRequestUri()
         val getMethod = GetMethod(URL(requestUri.toString()))
+
+        // First iteration won't follow redirections.
+        getMethod.followRedirects = false
+
         return try {
             val status = client.executeHttpMethod(getMethod)
             val response = getMethod.getResponseBodyAsString()!!

--- a/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/webfinger/responses/WebFingerResponse.kt
+++ b/owncloudComLibrary/src/main/java/com/owncloud/android/lib/resources/webfinger/responses/WebFingerResponse.kt
@@ -29,7 +29,7 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 data class WebFingerResponse(
     val subject: String,
-    val links: List<LinkItem>
+    val links: List<LinkItem>?
 )
 
 @JsonClass(generateAdapter = true)

--- a/owncloudComLibrary/src/test/java/com/owncloud/android/lib/resources/webfinger/responses/WebFingerResponseTest.kt
+++ b/owncloudComLibrary/src/test/java/com/owncloud/android/lib/resources/webfinger/responses/WebFingerResponseTest.kt
@@ -22,20 +22,20 @@ class WebFingerResponseTest {
     @Test
     fun `check rel in too much information - ok`() {
         val response = loadResponses(TOO_MUCH_INFORMATION_JSON)!!
-        Assert.assertEquals("https://gast.somedomain.de", response.links[0].href)
-        Assert.assertEquals("http://webfinger.owncloud/rel/server-instance", response.links[0].rel)
+        Assert.assertEquals("https://gast.somedomain.de", response.links!![0].href)
+        Assert.assertEquals("http://webfinger.owncloud/rel/server-instance", response.links!![0].rel)
     }
 
     @Test(expected = JsonDataException::class)
     fun `check key value pairs - ko - no href key`() {
         val response = loadResponses(BROKEN_JSON)!!
-        Assert.assertEquals("https://gast.somedomain.de", response.links[0].href)
+        Assert.assertEquals("https://gast.somedomain.de", response.links!![0].href)
     }
 
     @Test(expected = JsonDataException::class)
     fun `check key value pairs - ko - no rel key`() {
         val response = loadResponses(BROKEN_JSON)!!
-        Assert.assertEquals("https://gast.somedomain.de", response.links[0].href)
+        Assert.assertEquals("https://gast.somedomain.de", response.links!![0].href)
     }
 
     companion object {


### PR DESCRIPTION
Implementation https://github.com/owncloud/android/issues/3998


WebFinger call won't follow redirections. In case the lookup server is not directly accessible, we will continue the authentication flow with the regular `status.php` and `/remote.php/dav/files/`